### PR TITLE
[Hotfix] Release 18 v4.0.5 – foreground service permission in Android P

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId 'app.tasknearby.yashcreations.com.tasknearby'
         minSdkVersion 17
         targetSdkVersion 28
-        versionCode 17
-        versionName "4.0.4"
+        versionCode 18
+        versionName "4.0.5"
         vectorDrawables {
             useSupportLibrary true
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <!-- Billing permission -->
     <uses-permission android:name="com.android.vending.BILLING" />
+    <!-- Foreground Service permission for Android 9+ -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <!--
      Google play services adds the READ_PHONE_STATE permission by default for InstanceId generation
      on older devices. This might not be needed. However, please confirm this by testing.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 
     <!--App level string constants-->
     <string name="app_name" translatable="false">Task Nearby</string>
-    <string name="app_version" translatable="false">v4.0.3</string>
+    <string name="app_version" translatable="false">v4.0.5</string>
 
 
     <!--Activity titles-->


### PR DESCRIPTION
see #73 for more details.